### PR TITLE
[Mission4/오재원] 노션 클로닝 프로젝트

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>KDT-Notion-Cloning</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="/src/main.js" type="module"></script>
+  </body>
+</html>

--- a/src/AddRootDocumentButton.js
+++ b/src/AddRootDocumentButton.js
@@ -1,0 +1,23 @@
+export default function AddRootDocumentButton({ $target, initialState, onClick }) {
+  const $addRootDocumentButton = document.createElement('div');
+
+  $target.appendChild($addRootDocumentButton);
+
+  this.state = initialState;
+  console.log(this.state);
+  this.setState = nextState => {
+    this.state = nextState;
+
+    this.render();
+  };
+
+  this.render = () => {
+    $addRootDocumentButton.innerHTML = `
+        <button class="add-new-root-document">${this.state.title}</button>
+      `;
+  };
+
+  this.render();
+
+  $addRootDocumentButton.addEventListener('click', onClick);
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,12 @@
+import PostEditor from './PostEditor.js';
+import PostList from './PostList.js';
+
+export default function App({ $target, initialState }) {
+  const postList = new PostList({
+    $target
+  });
+
+  const postEditor = new PostEditor({
+    $target
+  });
+}

--- a/src/App.js
+++ b/src/App.js
@@ -7,14 +7,15 @@ export default function App({ $target, initialState }) {
     $target,
     inititalState: initialState,
     onClick: e => {
-      const target = e.target;
+      const { target } = e;
+      const { className } = target;
       const documentId = target.closest('li').dataset.id;
 
-      if (target.nodeName === 'SPAN') {
-        documentEditor.getDocument(documentId);
-      } else if (target.nodeName === 'BUTTON') {
+      if (className === 'add-document') {
         documentList.addDocument(+documentId);
         documentEditor.setState({ title: '', content: '', isLoad: true, documentId: documentId });
+      } else if (className === 'delete-document') {
+        documentList.deleteDocument(+documentId);
       }
     }
   });
@@ -28,4 +29,29 @@ export default function App({ $target, initialState }) {
       documentId: ''
     }
   });
+
+  this.render = () => {
+    const { pathname } = location;
+
+    if (pathname === '/') {
+      documentList.fetchDocument();
+      documentEditor.render();
+    } else if (pathname.indexOf('/documents/') === 0) {
+      const documentId = pathname.split('/')[2];
+      documentEditor.getDocument(documentId);
+    }
+  };
+
+  window.addEventListener('click', e => {
+    if (e.target.className === 'document') {
+      const href = e.target.closest('li').dataset.id;
+      history.pushState(null, null, `/documents/${href}`);
+
+      e.preventDefault();
+
+      this.render();
+    }
+  });
+
+  this.render();
 }

--- a/src/App.js
+++ b/src/App.js
@@ -7,9 +7,14 @@ export default function App({ $target, initialState }) {
     $target,
     inititalState: initialState,
     onClick: e => {
-      if (e.target.nodeName === 'SPAN') {
-        const documentId = e.target.closest('li').dataset.id;
+      const target = e.target;
+      const documentId = target.closest('li').dataset.id;
+
+      if (target.nodeName === 'SPAN') {
         documentEditor.getDocument(documentId);
+      } else if (target.nodeName === 'BUTTON') {
+        documentList.addDocument(+documentId);
+        documentEditor.setState({ title: '', content: '', isLoad: true, documentId: documentId });
       }
     }
   });
@@ -19,7 +24,8 @@ export default function App({ $target, initialState }) {
     initialState: {
       title: '',
       content: '',
-      isLoad: true
+      isLoad: true,
+      documentId: ''
     }
   });
 }

--- a/src/App.js
+++ b/src/App.js
@@ -6,14 +6,19 @@ export default function App({ $target, initialState }) {
   const documentList = new DocumentList({
     $target,
     inititalState: initialState,
-    onClick: e => {
+    onClick: async e => {
       const { target } = e;
       const { className } = target;
       const documentId = target.closest('li').dataset.id;
 
       if (className === 'add-document') {
-        documentList.addDocument(+documentId);
-        documentEditor.setState({ title: '', content: '', isLoad: true, documentId: documentId });
+        const newDoucmentId = await documentList.addDocument(+documentId);
+        documentEditor.setState({
+          title: '',
+          content: '',
+          isLoad: true,
+          documentId: newDoucmentId
+        });
       } else if (className === 'delete-document') {
         documentList.deleteDocument(+documentId);
       }

--- a/src/App.js
+++ b/src/App.js
@@ -1,12 +1,25 @@
-import PostEditor from './PostEditor.js';
-import PostList from './PostList.js';
+import DocumentEditor from './DocumentEditor.js';
+import DocumentList from './DocumentList.js';
+import { request } from './api.js';
 
 export default function App({ $target, initialState }) {
-  const postList = new PostList({
-    $target
+  const documentList = new DocumentList({
+    $target,
+    inititalState: initialState,
+    onClick: e => {
+      if (e.target.nodeName === 'SPAN') {
+        const documentId = e.target.closest('li').dataset.id;
+        documentEditor.getDocument(documentId);
+      }
+    }
   });
 
-  const postEditor = new PostEditor({
-    $target
+  const documentEditor = new DocumentEditor({
+    $target,
+    initialState: {
+      title: '',
+      content: '',
+      isLoad: true
+    }
   });
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,20 @@
+import AddRootDocumentButton from './AddRootDocumentButton.js';
 import DocumentEditor from './DocumentEditor.js';
 import DocumentList from './DocumentList.js';
-import { request } from './api.js';
 
 export default function App({ $target, initialState }) {
+  new AddRootDocumentButton({
+    $target,
+    initialState: {
+      title: 'Add New Document'
+    },
+    onClick: e => {
+      if (e.target.className === 'add-new-root-document') {
+        setNewDocumentEditor();
+      }
+    }
+  });
+
   const documentList = new DocumentList({
     $target,
     inititalState: initialState,
@@ -12,13 +24,7 @@ export default function App({ $target, initialState }) {
       const documentId = target.closest('li').dataset.id;
 
       if (className === 'add-document') {
-        const newDoucmentId = await documentList.addDocument(+documentId);
-        documentEditor.setState({
-          title: '',
-          content: '',
-          isLoad: true,
-          documentId: newDoucmentId
-        });
+        setNewDocumentEditor(documentId);
       } else if (className === 'delete-document') {
         documentList.deleteDocument(+documentId);
       }
@@ -59,4 +65,14 @@ export default function App({ $target, initialState }) {
   });
 
   this.render();
+
+  const setNewDocumentEditor = async (documentId = null) => {
+    const newDoucmentId = await documentList.addDocument(documentId ? +documentId : documentId);
+    documentEditor.setState({
+      title: '',
+      content: '',
+      isLoad: true,
+      documentId: newDoucmentId
+    });
+  };
 }

--- a/src/DocumentEditor.js
+++ b/src/DocumentEditor.js
@@ -36,13 +36,35 @@ export default function DocumentEditor({ $target, initialState }) {
     };
 
     this.setState(nextState);
+    onEditing();
   });
 
   this.getDocument = async documentId => {
     const nextState = await request(`/${documentId}`);
 
-    this.setState({ title: nextState.title, content: nextState.content, isLoad: true });
+    this.setState({
+      title: nextState.title,
+      content: nextState.content,
+      isLoad: true,
+      documentId: documentId
+    });
   };
 
-  this.render();
+  let timer = null;
+
+  const onEditing = () => {
+    if (!this.state.documentId) return;
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      request(`/${this.state.documentId}`, {
+        body: JSON.stringify({
+          title: this.state.title,
+          content: this.state.content
+        }),
+        method: 'PUT'
+      });
+    }, 1000);
+  };
+
+  // this.render();
 }

--- a/src/DocumentEditor.js
+++ b/src/DocumentEditor.js
@@ -1,0 +1,24 @@
+export default function PostEditor({ $target, initialState }) {
+  this.state = initialState;
+
+  const $postEditor = document.createElement('div');
+
+  $target.appendChild($postEditor);
+
+  this.setState = nextState => {
+    this.state = nextState;
+
+    this.render();
+  };
+
+  this.render = () => {
+    $postEditor.innerHTML = `
+      <ul>
+        <textarea>${this.state.title}</textarea>
+        <textarea>${this.state.content}</textarea>
+      </ul>
+    `;
+  };
+
+  this.render();
+}

--- a/src/DocumentEditor.js
+++ b/src/DocumentEditor.js
@@ -1,9 +1,11 @@
-export default function PostEditor({ $target, initialState }) {
+import { request } from './api.js';
+
+export default function DocumentEditor({ $target, initialState }) {
   this.state = initialState;
 
-  const $postEditor = document.createElement('div');
+  const $documentEditor = document.createElement('div');
 
-  $target.appendChild($postEditor);
+  $target.appendChild($documentEditor);
 
   this.setState = nextState => {
     this.state = nextState;
@@ -12,12 +14,34 @@ export default function PostEditor({ $target, initialState }) {
   };
 
   this.render = () => {
-    $postEditor.innerHTML = `
+    if (this.state.isLoad) {
+      $documentEditor.innerHTML = `
       <ul>
-        <textarea>${this.state.title}</textarea>
-        <textarea>${this.state.content}</textarea>
+        <textarea name="title">${this.state.title}</textarea>
+        <textarea name="content">${this.state.content}</textarea>
       </ul>
     `;
+    }
+
+    this.state.isLoad = false;
+  };
+
+  $documentEditor.addEventListener('keyup', e => {
+    const { target } = e;
+    const type = target.getAttribute('name');
+
+    const nextState = {
+      ...this.state,
+      [type]: target.value
+    };
+
+    this.setState(nextState);
+  });
+
+  this.getDocument = async documentId => {
+    const nextState = await request(`/${documentId}`);
+
+    this.setState({ title: nextState.title, content: nextState.content, isLoad: true });
   };
 
   this.render();

--- a/src/DocumentList.js
+++ b/src/DocumentList.js
@@ -28,9 +28,10 @@ export default function DocumentList({ $target, inititalState, onClick }) {
 
     const dfs = (node, level) => {
       documentsIndex.push(
-        `<li data-id="${node.id}"style="padding-left:${10 * level}px;">
-        <span>${node.title}</span>
-        <button>+</button>
+        `<li data-id="${node.id}"style="padding-left:${15 * level}px;">
+        <span class="document">${node.title}</span>
+        <button class="add-document">+</button>
+        <button class="delete-document">x</button>
         </li>`
       );
 
@@ -48,7 +49,7 @@ export default function DocumentList({ $target, inititalState, onClick }) {
 
   $document.addEventListener('click', onClick);
 
-  const fetchDocument = async () => {
+  this.fetchDocument = async () => {
     const documents = await request();
 
     this.setState(documents);
@@ -89,5 +90,43 @@ export default function DocumentList({ $target, inititalState, onClick }) {
     return nextState;
   };
 
-  fetchDocument();
+  this.deleteDocument = async documentId => {
+    request(`/${documentId}`, {
+      method: 'DELETE'
+    });
+    const nextState = deleteChildDocument(documentId);
+    this.setState(nextState);
+  };
+
+  const deleteChildDocument = documentId => {
+    const nextState = this.state;
+    let isRoot;
+
+    const moveChildDocumentToRoot = node => {
+      node.forEach(document => nextState.push(document));
+    };
+
+    const dfs = (node, parentNode, idx) => {
+      if (node.id === documentId) {
+        moveChildDocumentToRoot(node.documents);
+        isRoot ? parentNode.splice(idx, 1) : parentNode.documents.splice(idx, 1);
+        return;
+      }
+
+      if (node.documents.length > 0) {
+        isRoot = false;
+
+        node.documents.forEach((documents, idx) => {
+          dfs(documents, node, idx);
+        });
+      }
+    };
+
+    nextState.map((document, idx) => {
+      isRoot = true;
+      dfs(document, nextState, idx);
+    });
+
+    return nextState;
+  };
 }

--- a/src/DocumentList.js
+++ b/src/DocumentList.js
@@ -1,4 +1,4 @@
-export default function DocumentList({ $target, inititalState, onClcik }) {
+export default function DocumentList({ $target, inititalState, onClick }) {
   this.state = inititalState;
 
   const $document = document.createElement('div');
@@ -13,6 +13,8 @@ export default function DocumentList({ $target, inititalState, onClcik }) {
         ${documentsIndex.map(document => document.join('')).join('')}
         </ul>
       `;
+
+    $document.addEventListener('click', onClick);
   };
 
   this.orderDocuments = document => {
@@ -20,9 +22,10 @@ export default function DocumentList({ $target, inititalState, onClcik }) {
 
     const dfs = (node, level) => {
       documentsIndex.push(
-        `<li data-id="${node.id}"style="padding-left:${10 * level}px;">${
-          node.title
-        }<button>+</button></li>`
+        `<li data-id="${node.id}"style="padding-left:${10 * level}px;">
+        <span>${node.title}</span>
+        <button>+</button>
+        </li>`
       );
 
       if (node.documents.length > 0) {

--- a/src/DocumentList.js
+++ b/src/DocumentList.js
@@ -55,7 +55,7 @@ export default function DocumentList({ $target, inititalState, onClick }) {
     this.setState(documents);
   };
 
-  this.addDocument = async documentId => {
+  this.addDocument = async (documentId = null) => {
     const res = await request('', {
       method: 'POST',
       body: JSON.stringify({
@@ -65,7 +65,11 @@ export default function DocumentList({ $target, inititalState, onClick }) {
     });
 
     const newDocument = { id: res.id, title: res.title, documents: [] };
-    const nextState = addChildDocument(newDocument, documentId);
+
+    const nextState =
+      documentId === null
+        ? [...this.state, newDocument]
+        : addChildDocument(newDocument, documentId);
 
     this.setState(nextState);
 

--- a/src/DocumentList.js
+++ b/src/DocumentList.js
@@ -54,5 +54,40 @@ export default function DocumentList({ $target, inititalState, onClick }) {
     this.setState(documents);
   };
 
+  this.addDocument = async documentId => {
+    const res = await request('', {
+      method: 'POST',
+      body: JSON.stringify({
+        title: '문서 제목을 입력해주세요.',
+        parent: documentId
+      })
+    });
+
+    const newDocument = { id: res.id, title: res.title, documents: [] };
+    const nextState = addChildDocument(newDocument, documentId);
+
+    this.setState(nextState);
+  };
+
+  const addChildDocument = (newDocument, documentId) => {
+    const nextState = this.state;
+
+    const dfs = node => {
+      if (node.id === documentId) {
+        node.documents.push(newDocument);
+        return;
+      }
+
+      if (node.documents.length > 0) {
+        node.documents.forEach(documents => {
+          dfs(documents);
+        });
+      }
+    };
+
+    nextState.map(document => dfs(document));
+    return nextState;
+  };
+
   fetchDocument();
 }

--- a/src/DocumentList.js
+++ b/src/DocumentList.js
@@ -1,3 +1,5 @@
+import { request } from './api.js';
+
 export default function DocumentList({ $target, inititalState, onClick }) {
   this.state = inititalState;
 
@@ -5,8 +7,14 @@ export default function DocumentList({ $target, inititalState, onClick }) {
 
   $target.appendChild($document);
 
+  this.setState = nextState => {
+    this.state = nextState;
+
+    this.render();
+  };
+
   this.render = () => {
-    const documentsIndex = this.state.map(document => this.orderDocuments(document, 10));
+    const documentsIndex = this.state.map(document => orderDocuments(document, 10));
 
     $document.innerHTML = `
         <ul>
@@ -15,7 +23,7 @@ export default function DocumentList({ $target, inititalState, onClick }) {
       `;
   };
 
-  this.orderDocuments = document => {
+  const orderDocuments = document => {
     const documentsIndex = [];
 
     const dfs = (node, level) => {
@@ -40,5 +48,11 @@ export default function DocumentList({ $target, inititalState, onClick }) {
 
   $document.addEventListener('click', onClick);
 
-  this.render();
+  const fetchDocument = async () => {
+    const documents = await request();
+
+    this.setState(documents);
+  };
+
+  fetchDocument();
 }

--- a/src/DocumentList.js
+++ b/src/DocumentList.js
@@ -13,8 +13,6 @@ export default function DocumentList({ $target, inititalState, onClick }) {
         ${documentsIndex.map(document => document.join('')).join('')}
         </ul>
       `;
-
-    $document.addEventListener('click', onClick);
   };
 
   this.orderDocuments = document => {
@@ -39,6 +37,8 @@ export default function DocumentList({ $target, inititalState, onClick }) {
 
     return documentsIndex;
   };
+
+  $document.addEventListener('click', onClick);
 
   this.render();
 }

--- a/src/DocumentList.js
+++ b/src/DocumentList.js
@@ -1,0 +1,41 @@
+export default function DocumentList({ $target, inititalState, onClcik }) {
+  this.state = inititalState;
+
+  const $document = document.createElement('div');
+
+  $target.appendChild($document);
+
+  this.render = () => {
+    const documentsIndex = this.state.map(document => this.orderDocuments(document, 10));
+
+    $document.innerHTML = `
+        <ul>
+        ${documentsIndex.map(document => document.join('')).join('')}
+        </ul>
+      `;
+  };
+
+  this.orderDocuments = document => {
+    const documentsIndex = [];
+
+    const dfs = (node, level) => {
+      documentsIndex.push(
+        `<li data-id="${node.id}"style="padding-left:${10 * level}px;">${
+          node.title
+        }<button>+</button></li>`
+      );
+
+      if (node.documents.length > 0) {
+        node.documents.forEach(documents => {
+          dfs(documents, level + 1);
+        });
+      }
+    };
+
+    dfs(document, 0);
+
+    return documentsIndex;
+  };
+
+  this.render();
+}

--- a/src/DocumentList.js
+++ b/src/DocumentList.js
@@ -68,6 +68,8 @@ export default function DocumentList({ $target, inititalState, onClick }) {
     const nextState = addChildDocument(newDocument, documentId);
 
     this.setState(nextState);
+
+    return await res.id;
   };
 
   const addChildDocument = (newDocument, documentId) => {

--- a/src/PostList.js
+++ b/src/PostList.js
@@ -1,0 +1,1 @@
+export default function PostList({}) {}

--- a/src/PostList.js
+++ b/src/PostList.js
@@ -1,1 +1,0 @@
-export default function PostList({}) {}

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,20 @@
+const API_END_POINT = 'https://kdt.roto.codes/documents';
+
+export const request = async (url, options = {}) => {
+  try {
+    const res = fetch(`${API_END_POINT}${url}`, {
+      ...options,
+      'Content-Type': 'application/json',
+      'x-username': 'progwon'
+    });
+
+    if (res.ok) {
+      const json = await res.json();
+      return json;
+    }
+
+    throw new Error('API 호출 오류');
+  } catch (e) {
+    alert(e.message);
+  }
+};

--- a/src/api.js
+++ b/src/api.js
@@ -1,19 +1,20 @@
 const API_END_POINT = 'https://kdt.roto.codes/documents';
 
-export const request = async (url, options = {}) => {
+export const request = async (url = '', options = {}) => {
   try {
-    const res = fetch(`${API_END_POINT}${url}`, {
+    const res = await fetch(`${API_END_POINT}${url}`, {
       ...options,
-      'Content-Type': 'application/json',
-      'x-username': 'progwon'
+      headers: {
+        'Content-Type': 'application/json',
+        'x-username': 'progwon'
+      }
     });
 
     if (res.ok) {
-      const json = await res.json();
-      return json;
+      return res.json();
     }
 
-    throw new Error('API 호출 오류');
+    throw new Error();
   } catch (e) {
     alert(e.message);
   }

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,30 @@
+import App from './App.js';
+
+const DUMMY_DATA = [
+  {
+    id: 1, // Document id
+    title: '노션을 만들자', // Document title
+    documents: [
+      {
+        id: 2,
+        title: '블라블라',
+        documents: [
+          {
+            id: 3,
+            title: '함냐함냐',
+            documents: []
+          }
+        ]
+      }
+    ]
+  },
+  {
+    id: 4,
+    title: 'hello!',
+    documents: []
+  }
+];
+
+const $app = document.querySelector('#app');
+
+new App({ $target: $app, initialState: DUMMY_DATA });

--- a/src/main.js
+++ b/src/main.js
@@ -1,30 +1,5 @@
 import App from './App.js';
 
-const DUMMY_DATA = [
-  {
-    id: 1, // Document id
-    title: '노션을 만들자', // Document title
-    documents: [
-      {
-        id: 2,
-        title: '블라블라',
-        documents: [
-          {
-            id: 3,
-            title: '함냐함냐',
-            documents: []
-          }
-        ]
-      }
-    ]
-  },
-  {
-    id: 4,
-    title: 'hello!',
-    documents: []
-  }
-];
-
 const $app = document.querySelector('#app');
 
-new App({ $target: $app, initialState: DUMMY_DATA });
+new App({ $target: $app, initialState: {} });


### PR DESCRIPTION
## 컴포넌트 구조
### 1. DocumentList
- Document의 list들을 보여주는 컴포넌트입니다.
- 리스트들에 대한 클릭 이벤트와 트리 형태로 하위 노드 문서를 보여줍니다.
- 문서 옆의 +버튼을 클릭해 하위 문서를 작성할 수 있습니다.
- 문서 옆의 x 버튼을 클릭해 문서의 삭제가 가능합니다.

### 2. DocumentEditor
- Document를 작성하거나 수정할 수 있는 컴포넌트입니다.
- 리스트를 클릭했을때 저장된 글을 받아와서 보여주거나, 새 문서를 작성했을때 새로 만든 문서의 제목과 내용이 수정될 수 있도록 합니다.

### 3. AddRootDocumentButton
- 루트에 document를 추가 가능하게 만드는 버튼 컴포넌트입니다.
- 리스트의 render 함수가 호출될 때, 버튼까지 다시 render 될 필요가 없다고 생각해 분리해주었습니다.

### 4. App
- 컴포넌트들에 대한 상위 컴포넌트 역할을 하는 컴포넌트입니다.

## 기능 구현 (주요 커밋들을 가져왔습니다. 제목 클릭시 커밋으로 이동합니다.)
### [트리형태로 document list 보여주기](https://github.com/prgrms-fe-devcourse/w4-Project_Notion_VanillaJS/commit/3def8d2be9bf0829c5adbe7f0e0ec81f83e6286d)
- 먼저 만들어진 문서의 하위 문서들부터 보여주기 위해서는 DFS를 사용하는것이 좋다고 생각했습니다.

![image](https://user-images.githubusercontent.com/41986911/131972150-9126b305-f507-47c6-9a56-a67f0cd48cc8.png)
#### DFS 구현
- 만들어 놓은 DFS를 재귀적으로 호출하면서 트리를 순회합니다.
- 순회시 마다 documentsIndex 배열에 li 태그를 사용한 Template literals 값을 push 해줍니다.

```javascript
documentsIndex.push(
        `<li data-id="${node.id}"style="padding-left:${10 * level}px;">${
          node.title
        }<button>+</button></li>`
```


- 만약 하위 문서가 있는 경우 다시 DFS를 호출하고 level을 한 단계 올려줍니다.
- 레벨은 padding-left 값에 사용됩니다. 레벨이 깊을수록 padding-left 값이 증가하도록 만들어 하위 노드처럼 보이게 했습니다.

```javascript
      if (node.documents.length > 0) {
        node.documents.forEach(documents => {
          dfs(documents, level + 1);
        });
      }
    };
```

- 이후 documentIndex 배열을 return 받아 this.render()에서 .join('')을 통해 렌더링을 진행합니다.
- 
```javascript
this.render = () => {
    const documentsIndex = this.state.map(document => this.orderDocuments(document, 10));

    $document.innerHTML = `
        <ul>
        ${documentsIndex.map(document => document.join('')).join('')}
        </ul>
      `;
  };
```

### [글이 아닌 여백을 클릭해도 이벤트가 발생하는 경우 수정](https://github.com/prgrms-fe-devcourse/w4-Project_Notion_VanillaJS/commit/943f11c74d6ae84c47fd83451c812903e1120c10)
- 이벤트가 블록 속성을 가지고 있는 li 태그에 걸려있어 문서의 제목이 아닌 빈 여백을 클릭해도 이벤트가 발생했습니다.
- 문서 제목 클릭시에만 이벤트 발생하도록 만들기 위해 span 태그를 사용하도록 변경해주었습니다.
```javascript
`<li data-id="${node.id}"style="padding-left:${10 * level}px;">
        <span>${node.title}</span>
        <button>+</button>
        </li>`
```

### [render 함수 안에 존재하던 addEventListenr 함수 위치 조정](https://github.com/prgrms-fe-devcourse/w4-Project_Notion_VanillaJS/commit/3ab692d4f0a034f037144e4761f69442be06a00e)
- render 함수 안에 있던 addEventListenr를 함수 밖으로 꺼내주었습니다.
- render 안에 들어가있을 경우 계속해서 addEventListenr 함수가 호출되어 불 필요하다고 생각했습니다.

### [문서 추가 구현하기 (낙관적 업데이트)](https://github.com/prgrms-fe-devcourse/w4-Project_Notion_VanillaJS/commit/f016eb1bff6a857a53717b9072e0b3bec602bca8)
- 문서를 추가했을때 문서 목록을 표시하기 위해 GET API를 사용하는것보다, 상태에 추가한 이후에 바로 렌더링하는것이 더 효율적이라고 생각했습니다.
- 또한 다른 사용자가 자신의 문서를 수정할 일이 없다고 생각했습니다. 자신만의 문서 저장소를 가지기 때문에 낙관적 업데이틀 사용하기 좋은 환경이라 생각해 구현해보았습니다.
- 새 문서의 경우 DocumentList의 경우 title만 보여주면 되므로 response의 id, title, 하위 노드가 존재하지 않는 documents: []를 newDocument로 만들어 주었습니다.
- 이후 addChildDocument를 호출합니다.
```javascript
this.addDocument = async documentId => {
    const res = await request('', {
      method: 'POST',
      body: JSON.stringify({
        title: '문서 제목을 입력해주세요.',
        parent: documentId
      })
    });

    const newDocument = { id: res.id, title: res.title, documents: [] };
    const nextState = addChildDocument(newDocument, documentId);

    this.setState(nextState);
  };
```
- addChildDocument 함수는 추가한 문서를 상위 문서의 하위 문서에 넣어주는 기능을 합니다.
- 마찬가지로 dfs를 사용해 documentId와 node.id가 같은 경우 하위 문서에 값을 삽입하고 return 해 setState에 nextState로 넣어줍니다.
```javascript
const addChildDocument = (newDocument, documentId) => {
    const nextState = this.state;

    const dfs = node => {
      if (node.id === documentId) {
        node.documents.push(newDocument);
        return;
      }

      if (node.documents.length > 0) {
        node.documents.forEach(documents => {
          dfs(documents);
        });
      }
    };

    nextState.map(document => dfs(document));
    return nextState;
  };
```
- 이를 통해 문서를 추가 한후 GET API 요청 없이 상태를 통해 렌더링 하므로 빠르게 리스트를 보여줄 수 있었습니다.

### [문서 삭제 (낙관적 업데이트)](https://github.com/prgrms-fe-devcourse/w4-Project_Notion_VanillaJS/commit/7b4c8b791c0c604ee090da2b087746417172e746)

- 문서 삭제 또한 마찬가지로 낙관적 업데이트를 사용하면 GET API 통신을 줄일 수 있다고 생각했습니다.
- 문서 추가와 달랐던 점은 하위 노드의 parent 를 root로 만들어 줘야 한다는 점이었습니다.

- 먼저 request를 통해 DELETE 메서드를 호출했습니다.
- 이후 deleteChildDocument함수를 통해 nextState를 만들어 setState에 인자로 넘겨주었습니다.
```javascript
this.deleteDocument = async documentId => {
    request(`/${documentId}`, {
      method: 'DELETE'
    });
    const nextState = deleteChildDocument(documentId);
    this.setState(nextState);
  };
```

- deleteChildDocument 함수는 삭제할 노드의 부모 노드와 삭제할 노드의 인덱스를 통해 접근해야 했습니다.
- parentNode를 구하고 삭제할 노드의 index를 splice 하는 방식으로 삭제를 구현했습니다.

```javascript
const dfs = (node, parentNode, idx) => {
      if (node.id === documentId) {
        parentNode.documents.splice(idx, 1);
        return;
      }
```

- 문제는 루트 노드에서 발생했습니다.
- 루트 노드의 부모 노드는 documents라는 프로퍼티를 가지고 있지 않아 삭제하는데 문제가 발생했습니다.
- 이 때문에 isRoot 라는 flag를 사용해 예외처리를 진행해주었습니다.

```javascript

const dfs = (node, parentNode, idx) => {
      if (node.id === documentId) {
        isRoot ? parentNode.splice(idx, 1) : parentNode.documents.splice(idx, 1);
        return;
      }

      if (node.documents.length > 0) {
        isRoot = false;

        node.documents.forEach((documents, idx) => {
          dfs(documents, node, idx);
        });
      }
    };

```

- 하위 노드들을 루트 노드로 만들기 위해서 함수를 따로 만들어서 관리했고 이를 통해서 API 호출 없이 상태만을 통해 바로바로 리스트에 렌더링하는것이 가능했습니다.
```javascript
const moveChildDocumentToRoot = node => {
      node.forEach(document => nextState.push(document));
    };
```
### [문서 생성후 글 작성시 수정이 안되는 버그 수정](https://github.com/prgrms-fe-devcourse/w4-Project_Notion_VanillaJS/commit/bad428d62782169c18632061d8b12b8bf9d4e81f)

- 글을 생성한 후에 eidtor에서 생성한 문서의 documentId를 받아오지 않아 글 작성이 불가능했습니다.
- 이때 DocumentList.js에서 addDocument 함수의 return 값을 response의 id로 만들어 DocumentEditor의 setState를 사용해 글 작성이 가능하도록 수정해주었습니다.

```javascript
const newDoucmentId = await documentList.addDocument(+documentId);
        documentEditor.setState({
          title: '',
          content: '',
          isLoad: true,
          documentId: newDoucmentId
        });
```

## 배운점/아쉬운점
### 배운점
- 강의를 들으며 setState나 this.render()를 사용하는 형식에 대해서 익숙해진 것 같습니다. 처음에는 왜 사용하는지, 어떻게 사용하는지에 대해서 많이 어려웠지만 이번 프로젝트를 통해 익숙해질 수 있었던것 같습니다.
- 옳든 틀리든 이렇게 해보면 어떨까? 라는 생각을 직접 코드로 짜볼 수 있는 좋은 시간이었던 것 같습니다. 
- 특히 낙관적 업데이트 같은 경우 강의를 들으며 사용할 수만 있다면 한 번 직접 구현해보고 싶다는 생각을 했는데, 시간은 많이 걸렸지만 좋은 경험을 할 수 있었던 것 같습니다.

### 아쉬운점
- 커밋을 어떻게 작성해야 할지 아직은 감이 잘 안 오는것 같습니다. 
- 저번 과제의 경우 기능 별로 커밋을 작성하지 않아 이번 프로젝트에서 제대로 해보자! 라는 마음가짐으로 신경 써보았는데, push 후 커밋 내역들을 확인 해보니 명확하지 않다는 생각이 들기도 합니다. 이 부분에 대해서 좀 더 공부하고 싶습니다.
- style에 신경쓰지 못한점이 아쉽습니다. 현재 학과 졸업 자격증 공부와 스터디를 병행하다보니 많은 시간을 쏟지 못해 style 보다는 코드에 신경을 쓰자! 라는 생각으로 프로젝트를 진행했습니다 ㅠㅠ 시간이 남으면 UI에 대해서도 좀 더 고민해보고 공부해보고 싶습니다.

## 궁금한 점
- 컴포넌트의 상위 컴포넌트를 언제 어떻게 만들어야 하는지에 대해서 궁금합니다! 제 코드의 경우 editor와 list를 분리하는것이 맞는지, 더 좋은 방법이 있는지에 대해서 궁금합니다.
- dfs 함수의 경우 따로 분리가 가능한지에 대해서 궁금합니다. 순회부분은 비슷하지만 조건이 전부 달라 이 부분에 대해서 따로 함수로 분리하는 좋은 방법이 있는지 궁금합니다!
