### PR TITLE
[Mission4/이미란] 노션 클로닝 프로젝트

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,35 @@
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+KR:wght@200;400&display=swap');
+
+* {
+    font-family: 'IBM Plex Sans KR', sans-serif;
+}
+
+.notion_list {
+    width: 30%;
+    float: left;
+    padding-right: 10px;
+    height: 100%;
+}
+
+li {
+    padding-bottom: 10px;
+}
+
+.addBtn,
+.removeBtn {
+    width: 60px;
+    height: 30px;
+}
+
+.addRootBtn {
+    float: right;
+}
+
+span {
+    display: inline-block;
+    width: 100px;
+}
+
+.card-header {
+    width: 103%;
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" type="text/css" href="/css/style.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-KyZXEAg3QhqLMpG8r+8fhAXLRk2vvoC2f3B09zVXn8CA5QIVfZOJ3BCsw2P0p/We" crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-U1DAWAznBHeqEIlVSCgzq+c9gqGAJn5c/t99JyeKa9xxaYpSvHU5awsuZVVFIhvj" crossorigin="anonymous"></script>
+</head>
+<body>
+    <main id="app"></main>
+    <script src="/js/main.js"type="module"></script>
+</body>
+</html>

--- a/js/App.js
+++ b/js/App.js
@@ -1,0 +1,35 @@
+import NotionPage from "./NotionPage.js";
+import NotionEditPage from "./NotionEditPage.js";
+import { initRouter } from "./router.js";
+
+export default function App({ $target }) {
+    const notionPage = new NotionPage({ $target });
+
+    const notionEditPage = new NotionEditPage({
+        $target, initialState: {
+            documentId: "new",
+            parentId: null,
+            doc: {
+                title: "",
+                content: ""
+            }
+        }
+    })
+
+    this.route = async () => {
+        $target.innerHTML = "";
+        const { pathname } = window.location;
+
+        if (pathname === "/") {
+            notionPage.setState();
+        } else if (pathname.indexOf("/documents/") === 0) {
+            const [, , documentId] = pathname.split("/");
+            notionPage.setState();
+            notionEditPage.setState({ documentId });
+
+        }
+    }
+    this.route();
+
+    initRouter(() => this.route());
+}

--- a/js/Editor.js
+++ b/js/Editor.js
@@ -1,0 +1,47 @@
+export default function Editor({ $target, initialState = {
+    title: "",
+    content: ""
+}, onEditing }) {
+    const $editor = document.createElement("div");
+
+    let isInit = false;
+
+    this.state = initialState;
+
+    this.setState = (nextState) => {
+        this.state = nextState;
+        $editor.querySelector('[name=title]').value = this.state.title;
+        $editor.querySelector('[name=content]').value = this.state.content;
+
+        this.render();
+    }
+
+    $target.appendChild($editor);
+
+    this.render = () => {
+        if (!isInit) {
+            $editor.innerHTML = `
+                <input class="form-control" type="text" name="title" style="width: 50%" value="${this.state.title}" />
+                <textarea class="form-control" name="content" style="width:50%; height:400px;">${this.state.content}</textarea></div>
+            `;
+            isInit = true;
+        }
+    }
+
+    this.render();
+
+    $editor.addEventListener("keyup", e => {
+        e.preventDefault();
+        const { target } = e;
+        const name = target.getAttribute("name");
+
+        if (this.state[name] !== undefined) {
+            const nextState = {
+                ...this.state,
+                [name]: target.value
+            }
+            this.setState(nextState);
+            onEditing(this.state);
+        }
+    })
+}

--- a/js/NotionEditPage.js
+++ b/js/NotionEditPage.js
@@ -1,0 +1,93 @@
+import { request } from "./api.js";
+import Editor from "./Editor.js";
+import { getItem, removeItem, setItem } from "./storage.js";
+import { push } from "./router.js";
+
+export default function NotionEditPage({ $target, initialState }) {
+    const $page = document.createElement("div");
+    this.state = initialState;
+    let docLocalSaveKey = `temp-notion-${this.state.documentId}`;
+
+    const doc = getItem(docLocalSaveKey, {
+        title: "새 항목",
+        content: ""
+    });
+
+    let timer = null;
+
+    const editor = new Editor({
+        $target: $page,
+        initialState: doc,
+        onEditing: (doc) => {
+            if (timer !== null) {
+                clearTimeout(timer);
+            }
+            timer = setTimeout(async () => {
+                setItem(docLocalSaveKey, {
+                    ...doc,
+                    tempSaveDate: new Date()
+                });
+
+                const docId = doc.id;
+                alert("저장되었습니다.");
+
+                await request(`/documents/${docId}`, {
+                    method: "PUT",
+                    body: JSON.stringify(doc)
+                })
+                push(`/documents/${docId}`);
+                this.setState({
+                    documentId: docId
+                })
+                removeItem(docLocalSaveKey);
+            }, 2000)
+        }
+    });
+
+    this.setState = async (nextState) => {
+        if (this.state.documentId !== nextState.documentId) {
+            docLocalSaveKey = `temp-notion-${nextState.documentId}`;
+            this.state = nextState;
+            await fetchDoc();
+            return;
+        }
+
+        this.state = nextState;
+        this.render();
+        editor.setState(this.state.doc || {
+            title: "",
+            content: ""
+        });
+    }
+
+    this.render = () => {
+        $target.appendChild($page);
+    }
+
+    const fetchDoc = async () => {
+        const { documentId } = this.state;
+        if (documentId) {
+            const doc = await request(`/documents/${documentId}`)
+
+            const tempDoc = getItem(docLocalSaveKey, {
+                title: "",
+                content: ""
+            });
+
+            if (tempDoc.tempSaveDate && tempDoc.tempSaveDate > doc.updated_at) {
+                if (confirm("저장되지 않은 임시 데이터가 있습니다. 불러올까요?")) {
+                    this.setState({
+                        ...this.state,
+                        doc: tempDoc
+                    })
+                    return;
+                }
+            }
+
+            this.setState({
+                ...this.state,
+                doc
+            })
+        }
+    }
+}

--- a/js/NotionList.js
+++ b/js/NotionList.js
@@ -1,0 +1,56 @@
+export default function NotionList({ $target, initialState, onDocClick, onAdd, onRemove, documentData }) {
+  const $notionList = document.createElement("div");
+  $notionList.className = "notion_list card";
+
+  $target.appendChild($notionList);
+
+  this.state = initialState;
+
+  this.setState = (nextState) => {
+    this.state = nextState;
+    this.render();
+  }
+
+
+  const getDocuments = (docs) => {
+    return `
+        <ul>
+            ${docs.map(doc => `
+               <li data-id=${doc.id}><span>${doc.title}</span>
+                <button class="addBtn btn btn-outline-primary">추가</button> 
+                <button class="removeBtn btn btn-outline-danger">삭제</button>
+               </li>
+               ${doc.documents.length ? getDocuments(doc.documents) : ""}
+            `).join("")
+      }
+        </ul>
+    `;
+  }
+
+  this.render = () => {
+    $notionList.innerHTML = "<div class='card-header'><b>📋 이미란님의 노션</b><button class='addRootBtn btn btn-success'>새로 추가</button></div><br><br>";
+    $notionList.innerHTML += getDocuments(this.state);
+  }
+
+  this.render();
+
+  $notionList.addEventListener("click", (e) => {
+    e.preventDefault();
+    const $li = e.target.closest("li");
+    if ($li) {
+      const { id } = $li.dataset;
+      if (e.target.classList.contains("addBtn")) {
+        onAdd(id);
+      } else if (e.target.classList.contains("removeBtn")) {
+        onRemove(id);
+      } else {
+        onDocClick(id);
+      }
+
+    } else {
+      if (e.target.classList.contains("addRootBtn")) {
+        onAdd(null);
+      }
+    }
+  })
+}

--- a/js/NotionPage.js
+++ b/js/NotionPage.js
@@ -1,0 +1,47 @@
+import { request } from "./api.js";
+import NotionList from "./NotionList.js";
+import { push } from "./router.js";
+
+export default function NotionPage({ $target }) {
+    const $page = document.createElement("div");
+
+    const notionList = new NotionList({
+        $target: $page,
+        initialState: [],
+        onAdd: async (parentId) => {
+            const doc = {
+                title: "새 항목",
+                parent: parentId,
+            };
+            const createdDoc = await fetchDoc(doc);
+            push(`/documents/${createdDoc.id}`);
+        },
+        onRemove: async (id) => {
+            await request(`/documents/${id}`, {
+                method: "DELETE",
+            });
+            push('/');
+        },
+        onDocClick: (id) => {
+            push(`/documents/${id}`);
+        },
+        documentData: {}
+    });
+
+    this.setState = async () => {
+        const documents = await request("/documents");
+        notionList.setState(documents);
+        this.render();
+    }
+
+    const fetchDoc = async (doc) => {
+        return await request("/documents", {
+            method: "POST",
+            body: JSON.stringify(doc),
+        });
+    }
+
+    this.render = () => {
+        $target.appendChild($page);
+    }
+}

--- a/js/api.js
+++ b/js/api.js
@@ -1,0 +1,20 @@
+export const API_END_POINT = "https://kdt.roto.codes";
+
+export const request = async (url, options = {}) => {
+    try {
+        const res = await fetch(`${API_END_POINT}${url}`, {
+            ...options,
+            headers: {
+                "x-username": "miran",
+                "Content-Type": "application/json"
+            }
+        })
+
+        if (res.ok) {
+            return await res.json();
+        }
+        throw new Error("API 처리중 문제 발생");
+    } catch (e) {
+        alert(e.message);
+    }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,5 @@
+import App from "./App.js";
+
+const $target = document.querySelector("#app");
+
+new App({$target});

--- a/js/router.js
+++ b/js/router.js
@@ -1,0 +1,20 @@
+const ROUTE_CHANGE_EVENT_NAME = "route-change";
+
+export const initRouter = (onRoute) => {
+    window.addEventListener(ROUTE_CHANGE_EVENT_NAME, (e) => {
+        const { nextUrl } = e.detail;
+        if (nextUrl) {
+            history.pushState(null, null, nextUrl);
+            onRoute();
+        }
+
+    })
+}
+
+export const push = (nextUrl) => {
+    window.dispatchEvent(new CustomEvent("route-change", {
+        detail: {
+            nextUrl
+        }
+    }))
+}

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,0 +1,18 @@
+const storage = window.localStorage;
+
+export const getItem = (key, defaultValue) => {
+    try {
+        const storedValue = storage.getItem(key);
+        return storedValue ? JSON.parse(storedValue) : defaultValue;
+    } catch (e) {
+        return defaultValue;
+    }
+}
+
+export const setItem = (key, value) => {
+    storage.setItem(key, JSON.stringify(value));
+}
+
+export const removeItem = (key) => {
+    storage.removeItem(key);
+}


### PR DESCRIPTION
## 📌 과제 설명
### 노션 클로닝 프로젝트
* 바닐라 JS만을 이용해 노션을 클로닝
* 기본적인 레이아웃은 노션과 같으며, 스타일링, 컬러값 등은 원하는대로 커스텀

## 👩‍💻 요구 사항과 구현 내용 
<img src='https://ifh.cc/g/6wPNR3.jpg' border='0'>

### 기본요구사항
- [x] 화면 좌측에 Root Documents를 불러오는 API를 통해 루트 Documents를 렌더링
- [x] Root Document를 클릭하면 오른쪽 편집기 영역에 해당 Document의 Content를 렌더링
- [x] 해당 Root Document에 하위 Document가 있는 경우, 해당 Document 아래에 트리 형태로 렌더링
- [x] +와 같은 추가버튼을 클릭하면 클릭한 Document의 하위 Document로 새 Document를 생성하고 편집화면 렌더링
- [x] 편집하는 경우 Document Save API를 이용해 지속적으로 서버에 저장
- [x] History API를 이용해 SPA 형태로 구현

### 보너스요구사항
- [ ]  div와 contentEditable을 조합해서 좀 더 Rich한 에디터 구현
- [ ] 편집기 최하단에는 현재 편집 중인 Document의 하위 Document 링크를 렌더링
- [ ] 편집기 내에서 다른 Document name을 적은 경우, 자동으로 해당 Document의 편집 페이지로 이동하는 링크를 거는 기능 추가

### 추가 구현
- [x] 삭제기능

### 개선사항
- [ ] 편집화면 렌더링 시 편집화면 위치 고정
- [ ] validation 처리
- [ ] 삭제 기능 보완
- [ ] 뒤로 가기 처리 (history API)
- [ ] storage 부분 처리
- [ ] 스타일 보완

## ✅ PR 포인트 & 궁금한 점
아직 정리가 되지않은 미완성된 코드입니다.
